### PR TITLE
remove OSIV pattern and eager fetching

### DIFF
--- a/backend/src/main/java/com/codecool/tasx/config/auth/SecurityConfig.java
+++ b/backend/src/main/java/com/codecool/tasx/config/auth/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.codecool.tasx.model.auth.account.UserAccountDao;
 import com.codecool.tasx.model.company.CompanyDao;
 import com.codecool.tasx.model.company.project.ProjectDao;
 import com.codecool.tasx.model.company.project.task.TaskDao;
+import com.codecool.tasx.model.user.ApplicationUserDao;
 import com.codecool.tasx.service.auth.CookieService;
 import com.codecool.tasx.service.auth.CustomPermissionEvaluator;
 import com.codecool.tasx.service.auth.RefreshService;
@@ -46,8 +47,7 @@ public class SecurityConfig {
   public UserDetailsService userDetailsService(UserAccountDao userAccountDao) {
     return username -> (UserDetails) userAccountDao.findOneByEmailAndAccountType(
       username, AccountType.LOCAL).orElseThrow(() -> new UsernameNotFoundException(
-      String.format(
-        "%s account not found with the provided e-mail address",
+      String.format("%s account not found with the provided e-mail address",
         AccountType.LOCAL.getDisplayName())));
   }
 
@@ -98,10 +98,11 @@ public class SecurityConfig {
    */
   @Bean
   public MethodSecurityExpressionHandler expressionHandler(
-    CompanyDao companyDao, ProjectDao projectDao, TaskDao taskDao) {
+    ApplicationUserDao applicationUserDao, CompanyDao companyDao, ProjectDao projectDao,
+    TaskDao taskDao) {
     var expressionHandler = new DefaultMethodSecurityExpressionHandler();
     expressionHandler.setPermissionEvaluator(
-      new CustomPermissionEvaluator(companyDao, projectDao, taskDao));
+      new CustomPermissionEvaluator(applicationUserDao, companyDao, projectDao, taskDao));
     return expressionHandler;
   }
 }

--- a/backend/src/main/java/com/codecool/tasx/exception/user/UserNotFoundException.java
+++ b/backend/src/main/java/com/codecool/tasx/exception/user/UserNotFoundException.java
@@ -1,14 +1,11 @@
 package com.codecool.tasx.exception.user;
 
 public class UserNotFoundException extends RuntimeException {
-  private final Long id;
-
   public UserNotFoundException(Long id) {
     super("User with ID " + id + " was not found");
-    this.id = id;
   }
 
-  public Long getId() {
-    return id;
+  public UserNotFoundException() {
+    super("User was not found");
   }
 }

--- a/backend/src/main/java/com/codecool/tasx/model/auth/account/LocalUserAccount.java
+++ b/backend/src/main/java/com/codecool/tasx/model/auth/account/LocalUserAccount.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/codecool/tasx/model/auth/account/OAuth2UserAccount.java
+++ b/backend/src/main/java/com/codecool/tasx/model/auth/account/OAuth2UserAccount.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/backend/src/main/java/com/codecool/tasx/model/user/ApplicationUser.java
+++ b/backend/src/main/java/com/codecool/tasx/model/user/ApplicationUser.java
@@ -10,10 +10,14 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @NoArgsConstructor
@@ -28,38 +32,38 @@ public class ApplicationUser {
   @Column(nullable = false)
   private String username;
 
-  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.EAGER,
+  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.LAZY,
     orphanRemoval = true, cascade = CascadeType.ALL)
   private Set<UserAccount> accounts = new HashSet<>();
 
   @Enumerated(EnumType.STRING)
   private Set<GlobalRole> globalRoles = new HashSet<>();
 
-  @ManyToMany(mappedBy = "admins", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "admins", fetch = FetchType.LAZY)
   private Set<Company> adminCompanies = new HashSet<>();
 
-  @ManyToMany(mappedBy = "editors", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "editors", fetch = FetchType.LAZY)
   private Set<Company> editorCompanies = new HashSet<>();
 
-  @ManyToMany(mappedBy = "employees", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "employees", fetch = FetchType.LAZY)
   private Set<Company> employeeCompanies = new HashSet<>();
 
-  @ManyToMany(mappedBy = "admins", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "admins", fetch = FetchType.LAZY)
   private Set<Project> adminProjects = new HashSet<>();
 
-  @ManyToMany(mappedBy = "editors", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "editors", fetch = FetchType.LAZY)
   private Set<Project> editorProjects = new HashSet<>();
 
-  @ManyToMany(mappedBy = "assignedEmployees", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "assignedEmployees", fetch = FetchType.LAZY)
   private Set<Project> assignedProjects = new HashSet<>();
 
-  @ManyToMany(mappedBy = "assignedEmployees", fetch = FetchType.EAGER)
+  @ManyToMany(mappedBy = "assignedEmployees", fetch = FetchType.LAZY)
   private Set<Task> assignedTasks = new HashSet<>();
 
-  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private Set<CompanyJoinRequest> joinRequests = new HashSet<>();
 
-  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+  @OneToMany(mappedBy = "applicationUser", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private Set<ProjectJoinRequest> projectJoinRequests = new HashSet<>();
 
 

--- a/backend/src/main/java/com/codecool/tasx/model/user/ApplicationUserDao.java
+++ b/backend/src/main/java/com/codecool/tasx/model/user/ApplicationUserDao.java
@@ -1,9 +1,33 @@
 package com.codecool.tasx.model.user;
 
+import com.codecool.tasx.model.auth.account.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ApplicationUserDao extends JpaRepository<ApplicationUser, Long> {
-  void deleteAllByUsernameNotLike(String username);
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.adminCompanies WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchAdminCompanies(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.editorCompanies WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchEditorCompanies(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.employeeCompanies WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchEmployeeCompanies(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.adminProjects WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchAdminProjects(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.editorProjects WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchEditorProjects(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.assignedProjects WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchAssignedProjects(@Param("id") Long id);
+
+  @Query("SELECT u FROM ApplicationUser u JOIN FETCH u.assignedTasks WHERE u.id = :id")
+  Optional<ApplicationUser> findByIdAndFetchAssignedTasks(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/codecool/tasx/service/auth/RefreshService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/auth/RefreshService.java
@@ -11,6 +11,7 @@ import com.codecool.tasx.model.auth.account.UserAccountDao;
 import com.codecool.tasx.model.user.ApplicationUser;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
@@ -22,6 +23,7 @@ public class RefreshService {
     return jwtService.generateRefreshToken(payloadDto);
   }
 
+  @Transactional(readOnly = true)
   public RefreshResponseDto refresh(RefreshRequestDto refreshRequest) {
     String refreshToken = refreshRequest.refreshToken();
     TokenPayloadDto payload = jwtService.verifyRefreshToken(refreshToken);

--- a/backend/src/main/java/com/codecool/tasx/service/auth/UserProvider.java
+++ b/backend/src/main/java/com/codecool/tasx/service/auth/UserProvider.java
@@ -1,21 +1,29 @@
 package com.codecool.tasx.service.auth;
 
 import com.codecool.tasx.exception.auth.UnauthorizedException;
+import com.codecool.tasx.exception.user.UserNotFoundException;
 import com.codecool.tasx.model.auth.account.UserAccount;
 import com.codecool.tasx.model.user.ApplicationUser;
+import com.codecool.tasx.model.user.ApplicationUserDao;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserProvider {
+  private final ApplicationUserDao applicationUserDao;
 
-  @Transactional
+  @Transactional(readOnly = true)
   public ApplicationUser getAuthenticatedUser() throws UnauthorizedException {
     try {
-      UserAccount userAccount =
-        (UserAccount) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-      return userAccount.getApplicationUser();
+      Long userId =
+        (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+      ApplicationUser user = applicationUserDao.findById(userId).orElseThrow(
+        () -> new UserNotFoundException());
+      return user;
     } catch (Exception e) {
       throw new UnauthorizedException();
     }

--- a/backend/src/main/java/com/codecool/tasx/service/auth/oauth2/OAuth2UserAccountService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/auth/oauth2/OAuth2UserAccountService.java
@@ -1,6 +1,8 @@
 package com.codecool.tasx.service.auth.oauth2;
 
 import com.codecool.tasx.exception.auth.OAuth2ProcessingException;
+import com.codecool.tasx.exception.auth.UnauthorizedException;
+import com.codecool.tasx.exception.user.UserNotFoundException;
 import com.codecool.tasx.model.auth.account.*;
 import com.codecool.tasx.model.user.ApplicationUser;
 import com.codecool.tasx.model.user.ApplicationUserDao;
@@ -91,7 +93,9 @@ public class OAuth2UserAccountService extends DefaultOAuth2UserService {
     if (accountsWithMatchingEmail.isEmpty()) {
       return applicationUserDao.save(new ApplicationUser(username));
     }
-    return accountsWithMatchingEmail.stream().toList().getFirst().getApplicationUser();
+    UserAccount matchingAccount = accountsWithMatchingEmail.stream().toList().getFirst();
+    ApplicationUser user = matchingAccount.getApplicationUser();
+    return user;
   }
 
   private Optional<UserAccount> findExistingOAuth2Account(

--- a/backend/src/main/java/com/codecool/tasx/service/company/CompanyRoleService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/company/CompanyRoleService.java
@@ -31,7 +31,6 @@ public class CompanyRoleService {
   private final CustomPermissionEvaluator permissionEvaluator;
 
   @Transactional(readOnly = true)
-  @PreAuthorize("hasPermission(#companyId, 'Company', 'COMPANY_EMPLOYEE')")
   public Set<PermissionType> getUserPermissionsForCompany(Long companyId) {
     ApplicationUser user = userProvider.getAuthenticatedUser();
     Company company = companyDao.findById(companyId).orElseThrow(
@@ -44,10 +43,10 @@ public class CompanyRoleService {
 
     Set<PermissionType> permissions = new HashSet<>();
     permissions.add(PermissionType.COMPANY_EMPLOYEE);
-    if (permissionEvaluator.hasCompanyEditorAccess(user, company)) {
+    if (permissionEvaluator.hasCompanyEditorAccess(user.getId(), company)) {
       permissions.add(PermissionType.COMPANY_EDITOR);
     }
-    if (permissionEvaluator.hasCompanyAdminAccess(user, company)) {
+    if (permissionEvaluator.hasCompanyAdminAccess(user.getId(), company)) {
       permissions.add(PermissionType.COMPANY_ADMIN);
     }
     return permissions;

--- a/backend/src/main/java/com/codecool/tasx/service/company/CompanyService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/company/CompanyService.java
@@ -13,6 +13,7 @@ import com.codecool.tasx.model.user.ApplicationUser;
 import com.codecool.tasx.service.auth.UserProvider;
 import com.codecool.tasx.service.converter.CompanyConverter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -43,10 +44,12 @@ public class CompanyService {
   @Transactional(readOnly = true)
   public List<CompanyResponsePublicDTO> getCompaniesWithUser() throws UnauthorizedException {
     ApplicationUser applicationUser = userProvider.getAuthenticatedUser();
+    Hibernate.initialize(applicationUser.getEmployeeCompanies());
     List<Company> companies = applicationUser.getEmployeeCompanies().stream().toList();
     return companyConverter.getCompanyResponsePublicDtos(companies);
   }
 
+  @Transactional(readOnly = true)
   @PreAuthorize("hasPermission(#companyId, 'Company', 'COMPANY_EMPLOYEE')")
   public CompanyResponsePrivateDTO getCompanyById(Long companyId)
     throws CompanyNotFoundException, UnauthorizedException {

--- a/backend/src/main/java/com/codecool/tasx/service/company/project/ProjectRoleService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/company/project/ProjectRoleService.java
@@ -31,7 +31,6 @@ public class ProjectRoleService {
   private final CustomPermissionEvaluator permissionEvaluator;
 
   @Transactional(readOnly = true)
-  @PreAuthorize("hasPermission(#projectId, 'Project', 'PROJECT_ASSIGNED_EMPLOYEE')")
   public Set<PermissionType> getUserPermissionsForProject(Long companyId, Long projectId) {
     ApplicationUser user = userProvider.getAuthenticatedUser();
     Project project = projectDao.findByIdAndCompanyId(projectId, companyId).orElseThrow(
@@ -44,10 +43,10 @@ public class ProjectRoleService {
 
     Set<PermissionType> permissions = new HashSet<>();
     permissions.add(PermissionType.PROJECT_ASSIGNED_EMPLOYEE);
-    if (permissionEvaluator.hasProjectEditorAccess(user, project)) {
+    if (permissionEvaluator.hasProjectEditorAccess(user.getId(), project)) {
       permissions.add(PermissionType.PROJECT_EDITOR);
     }
-    if (permissionEvaluator.hasProjectAdminAccess(user, project)) {
+    if (permissionEvaluator.hasProjectAdminAccess(user.getId(), project)) {
       permissions.add(PermissionType.PROJECT_ADMIN);
     }
     return permissions;

--- a/backend/src/main/java/com/codecool/tasx/service/company/project/task/TaskRoleService.java
+++ b/backend/src/main/java/com/codecool/tasx/service/company/project/task/TaskRoleService.java
@@ -28,7 +28,6 @@ public class TaskRoleService {
   private final CustomPermissionEvaluator permissionEvaluator;
 
   @Transactional(readOnly = true)
-  @PreAuthorize("hasPermission(#taskId, 'Project', 'PROJECT_ASSIGNED_EMPLOYEE')")
   public Set<PermissionType> getUserPermissionsForTask(
     Long companyId, Long projectId, Long taskId) {
     ApplicationUser user = userProvider.getAuthenticatedUser();
@@ -40,7 +39,7 @@ public class TaskRoleService {
     }
 
     Set<PermissionType> permissions = new HashSet<>();
-    if (permissionEvaluator.hasTaskAssignedEmployeeAccess(user, task)) {
+    if (permissionEvaluator.hasTaskAssignedEmployeeAccess(user.getId(), task)) {
       permissions.add(PermissionType.TASK_ASSIGNED_EMPLOYEE);
     }
     return permissions;

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,14 +6,22 @@ spring:
     url: jdbc:postgresql://localhost:54321/projectmanagerdb
     username: devuser
     password: devpassword
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 5
+      idle-timeout: 1000
+      max-lifetime: 600000
+      connection-timeout: 30000
   jpa:
     hibernate:
       ddl-auto: create-drop
-#    properties:
-#      hibernate:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
 #        format_sql: true
 #    show_sql: true
-    open-in-view: true
+    open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect
   main:
     web-application-type: servlet
@@ -66,9 +74,10 @@ spring:
 logging:
   level:
     root: error
-    org.springframework: info
+#    org.springframework: info
+#    org.springframework.web: trace
     org.hibernate: error
-    org.hibernate.sql: error
+#    org.hibernate.type.descriptor.sql: trace
     org.springframework.transaction: error
     org.springframework.security: error
     org.springframework.mail: error


### PR DESCRIPTION
[related stackoverflow answer](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping#:~:text=What%20is%20the%20N%2B1%20query%20problem)

Three different key things have been modified on this branch:
- The Open Session In View pattern has been removed.
- Eager fetching was removed from the ApplicationUser entity, customized JPQL queries and Spring JPA transactional context is used instead to retrieve related data.
- The UserAccount entity as a whole is no longer placed in the Spring Security context, only an ID reference, and its GrantedAuthorities

Those three factors help in keeping the Spring Data JPA transactions on the level of the service methods, and with this, optimize the actual queries sent to the database, force joins instead of n+1 selects, and reduce the memory overhead on the java application.